### PR TITLE
Only look at the path when "path" filter selected

### DIFF
--- a/javascripts/utils.js
+++ b/javascripts/utils.js
@@ -17,7 +17,7 @@ function fits(current, storage, filter) {
         return url1.host === url2.host;
 
     } else if (filter === FILTER_BY_PATH) {
-        return (url1.protocol + url1.host + url1.path) == (url2.protocol + url2.host + url2.path);
+        return url1.path == url2.path;
         
     } else if (filter === FILTER_BY_FULL) {
         return current == storage;


### PR DESCRIPTION
Hey Eric,
I believe I found an error in the code and this would be a fix for it.

The original "path" filter would look at (url1.protocol + url1.host + url1.path. This must be an error because the result is the exactly the same as when the "full" filter is chosen. The "path" filter should be meant to match on the same paths on different domains, e.g. the "/contact" path on domains amazon.com, amazon.de, amazon.fr, etc.

This change would also require a minor bump version, given that the behaviour of the extension was modified.